### PR TITLE
add a throlling system to handle SLURM limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,9 @@ jobs:
         python-version: ["3.10", "3.14"]
         runs-on: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
 
-        include:
-          - python-version: "pypy-3.11"
-            runs-on: ubuntu-latest
+        # include:
+        #   - python-version: "pypy-3.11"
+        #     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,6 @@ jobs:
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --hook-stage manual --all-files
-      # - name: Run Pylint
-      # run: uvx nox -s pylint -- --output-format=github
-      - name: Run ruff
-        run: |
-          ruff check src/
-          ruff format --check src/
 
   checks:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           extra_args: --hook-stage manual --all-files
       # - name: Run Pylint
-        # run: uvx nox -s pylint -- --output-format=github
+      # run: uvx nox -s pylint -- --output-format=github
       - name: Run ruff
         run: |
           ruff check src/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,12 @@ jobs:
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --hook-stage manual --all-files
-      - name: Run Pylint
-        run: uvx nox -s pylint -- --output-format=github
+      # - name: Run Pylint
+        # run: uvx nox -s pylint -- --output-format=github
+      - name: Run ruff
+        run: |
+          ruff check src/
+          ruff format --check src/
 
   checks:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ help:
 # line removed from Makefile below
 #pip install -r ../requirements_doc.txt
 %: Makefile
-	
+
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 # add github action
 github:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,28 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+
+# line removed from Makefile below
+#pip install -r ../requirements_doc.txt
+%: Makefile
+	
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+# add github action
+github:
+	@make html
+	@cp -a _build/html/. ../docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,12 +100,14 @@ warn_return_any = false
 module = "turboblast.*"
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
+disable_error_code = "type-arg"
 
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 ignore_errors = true
+
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   "submitit",
+  "tqdm",
 ]
 
 [project.urls]
@@ -91,11 +92,21 @@ enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
+ignore_missing_imports = true
+disallow_any_unimported = false
+warn_return_any = false
 
 [[tool.mypy.overrides]]
 module = "turboblast.*"
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+ignore_errors = true
+
 
 
 [tool.ruff]
@@ -142,13 +153,21 @@ extend-select = [
 ignore = [
   "PLR09",    # Too many <...>
   "PLR2004",  # Magic value used in comparison
+   "TRY003",    # Long exception messages
+    "EM102",     # F-strings in exceptions
+    "TRY300",    # Return in try block
+    "PERF203",   # Try-except in loop
+    "BLE001",    # Blind exception (déjà discuté)
 ]
+
+
 # Uncomment if using a _compat.typing backport
 # typing-modules = ["turboblast._compat.typing"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["T20"]
 "noxfile.py" = ["T20"]
+
 
 
 [tool.pylint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Changelog = "https://github.com/umr-lops/turboblast/releases"
 test = [
   "pytest >=9",
   "pytest-cov >=7",
+  "pytest-timeout >=2",
   "ruff >=0.9.0",
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Changelog = "https://github.com/umr-lops/turboblast/releases"
 test = [
   "pytest >=9",
   "pytest-cov >=7",
+  "ruff >=0.9.0",
 ]
 dev = [
   { include-group = "test" },

--- a/src/turboblast/blaster.py
+++ b/src/turboblast/blaster.py
@@ -573,7 +573,7 @@ def main(args: argparse.Namespace) -> None:
         "Submitting in chunks of %d (%d chunks total)...", CHUNK_SIZE, total_chunks
     )
 
-    process_func = functools.partial(process_line, args.bash_slurm_exec)  # type: ignore[type-arg]
+    process_func = functools.partial(process_line, args.bash_slurm_exec)
 
     global_completed = 0
     global_failed = 0

--- a/src/turboblast/blaster.py
+++ b/src/turboblast/blaster.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import time
+import subprocess
 import submitit  # type: ignore[import-not-found]
 
 from turboblast.logo import LOGO
@@ -23,6 +25,37 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
+
+
+
+# À mettre en constante en haut du fichier
+MAX_JOBS_IN_QUEUE = 5000   # seuil conservateur, à adapter
+QUEUE_POLL_INTERVAL = 60   # secondes entre chaque vérification
+
+
+def count_user_jobs() -> int:
+    """Retourne le nombre de jobs (pending + running) de l'utilisateur."""
+    result = subprocess.run(
+        ["squeue", "-u", os.environ["USER"], "-h", "--states=PD,R"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return len(result.stdout.strip().splitlines())
+
+
+def wait_for_queue_space(max_jobs: int, poll_interval: int) -> None:
+    """Bloque jusqu'à ce qu'il y ait de la place dans la queue."""
+    while True:
+        current = count_user_jobs()
+        if current < max_jobs:
+            return
+        logger.info(
+            "Queue saturée (%d jobs en cours), attente %ds...",
+            current,
+            poll_interval,
+        )
+        time.sleep(poll_interval)
 
 
 def process_line(slurmexe: str, options_one_line: str) -> None:
@@ -195,6 +228,9 @@ def main(args: argparse.Namespace) -> None:
 
     # Loop through the inputs in chunks
     for chunk_idx, i in enumerate(range(0, len(array_inputs), chunk_size), start=1):
+        # Attendre de la place avant chaque soumission
+        wait_for_queue_space(MAX_JOBS_IN_QUEUE, QUEUE_POLL_INTERVAL)
+
         chunk = array_inputs[i : i + chunk_size]
         logger.info(
             "Submitting chunk %d/%d (size: %d, starting at index %d)...",
@@ -204,16 +240,13 @@ def main(args: argparse.Namespace) -> None:
             i,
         )
 
-        # This will create a NEW Slurm Job Array for every 1000 tasks
         jobs = executor.map_array(process_func, chunk)
-
         logger.info(
-            "Chunk %d submitted successfully. Job Array ID: %s",
+            "Chunk %d submitted. Job Array ID: %s",
             chunk_idx,
             jobs[0].job_id,
         )
         all_jobs.extend(jobs)
-
     logger.info(
         "Successfully submitted all %d tasks across %d Job Arrays.",
         len(all_jobs),

--- a/src/turboblast/blaster.py
+++ b/src/turboblast/blaster.py
@@ -7,11 +7,11 @@ import os
 import shlex
 import subprocess
 import sys
+import time
 from pathlib import Path
 
-import time
-import subprocess
-import submitit  # type: ignore[import-not-found]
+import submitit
+from tqdm import tqdm
 
 from turboblast.logo import LOGO
 
@@ -26,49 +26,113 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Slurm configuration
+# ---------------------------------------------------------------------------
+
+# Maximum number of tasks per job array chunk.
+# Must stay strictly below MaxArraySize (= 1001 on this cluster).
+CHUNK_SIZE = 1000
+
+# Seconds between polls when waiting for a batch to complete.
+BATCH_POLL_INTERVAL = 30
+
+# Maximum number of sbatch submission retries on transient failures.
+SUBMIT_MAX_RETRIES = 2
+
+# Base backoff in seconds between submission retries (multiplied by attempt number).
+SUBMIT_RETRY_BACKOFF = 5.0
+
+# Terminal Slurm job states — a batch is done when all tasks reach one of these.
+TERMINAL_STATES = frozenset(
+    {
+        "COMPLETED",
+        "FAILED",
+        "CANCELLED",
+        "TIMEOUT",
+        "OUT_OF_MEMORY",
+        "NODE_FAIL",
+        "PREEMPTED",
+        "BOOT_FAIL",
+        "DEADLINE",
+    }
+)
 
 
-# À mettre en constante en haut du fichier
-MAX_JOBS_IN_QUEUE = 5000   # seuil conservateur, à adapter
-QUEUE_POLL_INTERVAL = 60   # secondes entre chaque vérification
+# En haut du fichier, après les imports et constantes
+class ChunkSubmissionError(RuntimeError):
+    """Raised when a chunk fails to submit after all retry attempts."""
 
-
-def count_user_jobs() -> int:
-    """Retourne le nombre de jobs (pending + running) de l'utilisateur."""
-    result = subprocess.run(
-        ["squeue", "-u", os.environ["USER"], "-h", "--states=PD,R"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return len(result.stdout.strip().splitlines())
-
-
-def wait_for_queue_space(max_jobs: int, poll_interval: int) -> None:
-    """Bloque jusqu'à ce qu'il y ait de la place dans la queue."""
-    while True:
-        current = count_user_jobs()
-        if current < max_jobs:
-            return
-        logger.info(
-            "Queue saturée (%d jobs en cours), attente %ds...",
-            current,
-            poll_interval,
+    def __init__(self, chunk_idx: int, total_chunks: int, max_retries: int):
+        self.chunk_idx = chunk_idx
+        self.total_chunks = total_chunks
+        self.max_retries = max_retries
+        super().__init__(
+            f"Chunk {chunk_idx}/{total_chunks}: submission failed after {max_retries} attempts."
         )
-        time.sleep(poll_interval)
+
+
+def parse_memory_to_gb(value: str) -> float:
+    """Parses a human-readable memory string and returns the value in gigabytes.
+
+    Accepts an integer with an optional unit suffix (case-insensitive).
+    Bare integers are assumed to be gigabytes for backward compatibility.
+
+    Args:
+        value (str): Memory string, e.g. ``"2G"``, ``"512M"``, ``"4GB"``, ``"1024MB"``.
+
+    Returns:
+        float: Memory in gigabytes, as expected by submitit's ``mem_gb`` parameter.
+
+    Raises:
+        argparse.ArgumentTypeError: If the value cannot be parsed.
+    """
+    value = value.strip().upper().replace(" ", "")
+
+    # Strip trailing 'B' so both "MB" and "M", "GB" and "G" are handled uniformly.
+    if value.endswith("MB"):
+        unit, number = "M", value[:-2]
+    elif value.endswith("GB"):
+        unit, number = "G", value[:-2]
+    elif value.endswith("M"):
+        unit, number = "M", value[:-1]
+    elif value.endswith("G"):
+        unit, number = "G", value[:-1]
+    else:
+        # No unit — assume gigabytes for backward compatibility with --mem-gb.
+        unit, number = "G", value
+
+    try:
+        amount = float(number)
+    except ValueError as err:
+        raise argparse.ArgumentTypeError(
+            f"Invalid memory value: {value!r}. "
+            "Expected an integer with optional unit suffix (M, MB, G, GB). "
+            "Examples: 512M, 2G, 4GB, 1024MB."
+        ) from err
+
+    if amount <= 0:
+        raise argparse.ArgumentTypeError(f"Memory must be positive, got {amount}.")
+
+    return amount / 1024 if unit == "M" else amount
+
+
+# ---------------------------------------------------------------------------
+# Task execution (runs on the compute node via submitit)
+# ---------------------------------------------------------------------------
 
 
 def process_line(slurmexe: str, options_one_line: str) -> None:
     """Executes a single task in the Slurm job array by calling a bash script.
 
-    This function is serialized and executed on the Slurm compute node by submitit.
-    It constructs the command, sets up the environment, and streams both standard
-    output and standard error directly to the submitit log files.
+    This function is serialized and executed on the Slurm compute node by
+    submitit.  It constructs the command, sets up the environment, and streams
+    both standard output and standard error directly to the submitit log files.
 
     Args:
         slurmexe (str): The path to the bash executable/script to run.
         options_one_line (str): A string containing the command-line arguments
-            to pass to the bash script (e.g., "--input file.txt --output dir/").
+            to pass to the bash script (e.g., ``"--input file.txt --output dir/"``).
 
     Raises:
         subprocess.CalledProcessError: If the bash command exits with a non-zero
@@ -76,14 +140,10 @@ def process_line(slurmexe: str, options_one_line: str) -> None:
     """
     logger.info("Starting computation for options: %s", options_one_line)
 
-    # Construct the command
-    # shlex.split is safer than string.split() if your options contain quoted strings
-    # RUF005: Use unpacking instead of list concatenation
+    # shlex.split handles quoted arguments safely (safer than str.split())
     cmd = ["bash", slurmexe, *shlex.split(options_one_line)]
-
     logger.info("Executing command: %s", " ".join(cmd))
 
-    # 1. Prepare the environment correctly
     full_env = os.environ.copy()
     full_env["PYTHONUNBUFFERED"] = "1"
 
@@ -98,31 +158,292 @@ def process_line(slurmexe: str, options_one_line: str) -> None:
             stderr=subprocess.STDOUT,
             env=full_env,
         )
-        # Flush to ensure everything is written to the submitit .out file immediately
+        # Flush to ensure everything is written to the submitit .out file immediately.
         sys.stdout.flush()
         logger.info("Task completed successfully for options: %s", options_one_line)
 
     except subprocess.CalledProcessError as e:
-        # TRY400: Use logging.exception instead of logging.error inside except block
         logger.exception(
             "Task failed for options: %s (exit status %s)",
             options_one_line,
             e.returncode,
         )
-        # TRY201: Use bare raise
         raise
 
 
-def parser_args() -> argparse.Namespace:
-    """Parses command-line arguments for the submitit client.
+# ---------------------------------------------------------------------------
+# Batch submission with retry
+# ---------------------------------------------------------------------------
+
+
+def submit_chunk_with_retry(
+    executor: submitit.AutoExecutor,
+    process_func: functools.partial,
+    chunk: list[str],
+    chunk_idx: int,
+    total_chunks: int,
+) -> list[submitit.Job]:
+    """Submits a single job array chunk with retries on transient sbatch failures.
+
+    Mirrors the retry logic used by the Airflow Slurm provider: up to
+    ``SUBMIT_MAX_RETRIES`` attempts, with a linearly increasing backoff between
+    attempts.  A failed attempt is logged as a warning; only a full exhaustion
+    of retries raises an exception.
+
+    Args:
+        executor (submitit.AutoExecutor): Configured submitit executor.
+        process_func (functools.partial): Partially applied task function.
+        chunk (list[str]): Input lines for this batch.
+        chunk_idx (int): 1-based index of this chunk (for logging).
+        total_chunks (int): Total number of chunks (for logging).
 
     Returns:
-        argparse.Namespace: An object containing all the parsed command-line
-            arguments and their values.
-    """
+        list[submitit.Job]: The submitted job handles for this chunk.
 
-    # formatter_class=argparse.RawDescriptionHelpFormatter is REQUIRED
-    # to preserve the newlines and spaces of the ASCII art logo!
+    Raises:
+        RuntimeError: If all retry attempts are exhausted.
+    """
+    last_exc: Exception | None = None
+
+    for attempt in range(1, SUBMIT_MAX_RETRIES + 1):
+        try:
+            jobs = executor.map_array(process_func, chunk)
+            logger.debug(
+                "Chunk %d/%d submitted (attempt %d). Job Array ID: %s",
+                chunk_idx,
+                total_chunks,
+                attempt,
+                jobs[0].job_id,
+            )
+            return jobs
+
+        except Exception as exc:
+            # Catch all exceptions during submission to enable retry logic.
+            # Transient failures (network, Slurm congestion, etc.) can raise
+            # various exception types. We preserve the last exception to
+            # raise it if all retries fail.
+            last_exc = exc
+            logger.debug(
+                "Chunk %d/%d — submission attempt %d/%d failed: %s",
+                chunk_idx,
+                total_chunks,
+                attempt,
+                SUBMIT_MAX_RETRIES,
+                exc,
+            )
+            if attempt < SUBMIT_MAX_RETRIES:
+                backoff = SUBMIT_RETRY_BACKOFF * attempt
+                logger.info("Retrying in %.0fs...", backoff)
+                time.sleep(backoff)
+    raise ChunkSubmissionError(
+        chunk_idx, total_chunks, SUBMIT_MAX_RETRIES
+    ) from last_exc
+
+
+# ---------------------------------------------------------------------------
+# Batch completion polling
+# ---------------------------------------------------------------------------
+
+
+def wait_for_batch_completion(
+    jobs: list[submitit.Job],
+    chunk_idx: int,
+    total_chunks: int,
+    stall_timeout_min: int = 0,
+) -> tuple[int, int]:
+    """Blocks until every job in a batch reaches a terminal Slurm state.
+
+    Polls submitit job states every ``BATCH_POLL_INTERVAL`` seconds and updates
+    a tqdm progress bar in real time.  This sequential, blocking approach ensures
+    at most one job array is in flight at a time, which prevents ``MaxJobCount``
+    saturation on the cluster (strategy borrowed from the Airflow Slurm provider).
+
+    The progress bar tracks completed tasks and shows live counts of each Slurm
+    state (RUNNING, PENDING, FAILED, NODE_FAIL, …) in its postfix.
+
+    If ``stall_timeout_min`` > 0, any tasks still non-terminal after that many
+    minutes without progress are cancelled via ``scancel`` and counted as failed.
+
+    Args:
+        jobs (list[submitit.Job]): Job handles returned by ``map_array()``.
+        chunk_idx (int): 1-based index of this chunk (for logging).
+        total_chunks (int): Total number of chunks (for logging).
+        stall_timeout_min (int): Minutes without progress before cancelling
+            stuck tasks. 0 = disabled (wait forever).
+
+    Returns:
+        tuple[int, int]: ``(completed, failed)`` task counts.
+    """
+    total = len(jobs)
+    logger.debug(
+        "Waiting for batch %d/%d to complete (%d tasks)...",
+        chunk_idx,
+        total_chunks,
+        total,
+    )
+
+    with tqdm(
+        total=total,
+        desc=f"Batch {chunk_idx}/{total_chunks}",
+        unit="task",
+        dynamic_ncols=True,
+        leave=True,
+        file=sys.stdout,
+    ) as pbar:
+        prev_terminal = 0
+        # Initialised here so last_progress_time is always defined.
+        last_progress_time = time.monotonic()
+
+        while True:
+            time.sleep(BATCH_POLL_INTERVAL)
+
+            # Collect per-task states via submitit (wraps squeue internally).
+            states: dict[str, int] = {}
+            for job in jobs:
+                try:
+                    state = job.state
+                except (
+                    submitit.core.utils.FailedJobError,
+                    AttributeError,
+                    RuntimeError,
+                ) as e:
+                    # Ces exceptions sont attendues dans le contexte submitit/Slurm
+                    logger.debug("Job state query failed: %s: %s", type(e).__name__, e)
+                    state = "UNKNOWN"
+                except Exception as e:
+                    # Attraper les autres exceptions mais avec log de warning
+                    # et propagation des exceptions système critiques
+                    if isinstance(e, (KeyboardInterrupt, SystemExit)):
+                        raise
+                    logger.warning(
+                        "Unexpected error in job state polling: %s", e, exc_info=True
+                    )
+                    state = "UNKNOWN"
+                states[state] = states.get(state, 0) + 1
+
+            # Count terminal tasks — submitit exposes its own state names
+            # ("COMPLETED", "FAILED") as well as raw Slurm states for the
+            # other terminal conditions (NODE_FAIL, TIMEOUT, etc.).
+            n_terminal = sum(
+                count
+                for state, count in states.items()
+                if state.upper() in TERMINAL_STATES or state in ("COMPLETED", "FAILED")
+            )
+
+            # Advance the bar by however many new terminal tasks appeared.
+            delta = n_terminal - prev_terminal
+            if delta > 0:
+                pbar.update(delta)
+                # Reset the stall clock whenever progress is observed.
+                last_progress_time = time.monotonic()
+
+            # Stall detection: computed every cycle, not just when delta > 0.
+            stalled_min = (time.monotonic() - last_progress_time) / 60
+            if stall_timeout_min > 0 and stalled_min >= stall_timeout_min:
+                stuck_jobs = [j for j in jobs if j.state.upper() not in TERMINAL_STATES]
+                job_ids = {j.job_id.split("_")[0] for j in stuck_jobs}
+                logger.warning(
+                    "Batch %d/%d stalled for %.0f min with %d task(s) "
+                    "non-terminal. Cancelling: %s",
+                    chunk_idx,
+                    total_chunks,
+                    stalled_min,
+                    len(stuck_jobs),
+                    job_ids,
+                )
+                for jid in job_ids:
+                    subprocess.run(["scancel", jid], check=False)
+                # Wait one cycle for Slurm to process the cancellations.
+                time.sleep(BATCH_POLL_INTERVAL)
+                completed = states.get("COMPLETED", 0)
+                failed = total - completed
+                pbar.set_postfix(
+                    {
+                        "completed": completed,
+                        "failed": failed,
+                        "cancelled": len(stuck_jobs),
+                    },
+                    refresh=True,
+                )
+                logger.warning(
+                    "Batch %d/%d force-finished after stall — "
+                    "completed=%d  failed=%d  cancelled=%d",
+                    chunk_idx,
+                    total_chunks,
+                    completed,
+                    failed,
+                    len(stuck_jobs),
+                )
+                return completed, failed
+
+            prev_terminal = n_terminal
+
+            # Build a compact postfix showing every non-zero state.
+            # Prioritise actionable states first (RUNNING, PENDING) then
+            # failures, so the most important info is never truncated.
+            state_order = [
+                "RUNNING",
+                "PENDING",
+                "COMPLETED",
+                "FAILED",
+                "NODE_FAIL",
+                "TIMEOUT",
+                "CANCELLED",
+                "UNKNOWN",
+            ]
+            postfix_parts = {}
+            for s in state_order:
+                if states.get(s, 0):
+                    postfix_parts[s.lower()] = states[s]
+            # Append any remaining states not in the priority list.
+            for s, n in states.items():
+                if s not in state_order and n:
+                    postfix_parts[s.lower()] = n
+            # Show stall countdown when stall detection is enabled.
+            if stall_timeout_min > 0 and stalled_min > 0:
+                elapsed_mins = int(stalled_min)
+                postfix_parts["stall"] = f"{elapsed_mins}/{stall_timeout_min}min"  # type: ignore[assignment]
+            pbar.set_postfix(postfix_parts)
+
+            parts = [f"{s}={n}" for s, n in sorted(states.items())]
+            logger.debug(
+                "Batch %d/%d — total=%d  terminal=%d  [%s]",
+                chunk_idx,
+                total_chunks,
+                total,
+                n_terminal,
+                "  ".join(parts),
+            )
+
+            if n_terminal >= total:
+                completed = states.get("COMPLETED", 0)
+                failed = total - completed
+                pbar.set_postfix(
+                    {"completed": completed, "failed": failed},
+                    refresh=True,
+                )
+                logger.info(
+                    "Batch %d/%d finished — completed=%d  failed=%d",
+                    chunk_idx,
+                    total_chunks,
+                    completed,
+                    failed,
+                )
+                return completed, failed
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parser_args() -> argparse.Namespace:
+    """Parses command-line arguments for the turboblaster client.
+
+    Returns:
+        argparse.Namespace: An object containing all parsed arguments.
+    """
+    # RawDescriptionHelpFormatter is required to preserve the ASCII art logo.
     parser = argparse.ArgumentParser(
         description=LOGO, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -137,7 +458,14 @@ def parser_args() -> argparse.Namespace:
         "--timeout-min", type=int, default=20, help="Timeout in minutes for each task"
     )
     parser.add_argument(
-        "--mem-gb", type=int, default=2, help="Memory in GB for each task"
+        "--mem",
+        type=str,
+        default="2G",
+        help=(
+            "Memory per task. Accepts an integer with optional unit suffix: "
+            "M or MB for megabytes, G or GB for gigabytes (case-insensitive). "
+            "Examples: --mem 512M  --mem 2G  --mem 4GB  --mem 1024MB"
+        ),
     )
     parser.add_argument(
         "--cpus-per-task", type=int, default=1, help="Number of CPUs per task"
@@ -149,7 +477,7 @@ def parser_args() -> argparse.Namespace:
         "--listing-input",
         type=str,
         required=True,
-        help="Path to a file containing input lines",
+        help="Path to a file containing one input argument per line",
     )
     parser.add_argument(
         "--bash-slurm-exec", type=str, required=True, help="Path to the bash script"
@@ -160,40 +488,71 @@ def parser_args() -> argparse.Namespace:
         default="submitit_logs_array",
     )
     parser.add_argument(
-        "--slurm-array-parallelism", type=int, default=20, help="Max concurrent tasks"
+        "--slurm-array-parallelism",
+        type=int,
+        default=20,
+        help="Max concurrent tasks per job array (maps to %%N in --array=0-999%%N)",
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        default=False,
+        help="Stop submitting further batches if any task in the current batch fails",
+    )
+    parser.add_argument(
+        "--batch-stall-timeout-min",
+        type=int,
+        default=0,
+        help=(
+            "Cancel remaining tasks and move to the next batch if no progress "
+            "is observed for this many minutes. 0 = disabled (wait forever)."
+        ),
     )
     return parser.parse_args()
 
 
-def main(args: argparse.Namespace) -> None:
-    """Configures and submits the job arrays to the Slurm cluster.
+# ---------------------------------------------------------------------------
+# Main submission logic
+# ---------------------------------------------------------------------------
 
-    This function reads the input file, configures the submitit AutoExecutor
-    with the required Slurm parameters (memory, partition, time, etc.), and
-    submits the jobs in chunks to respect Slurm array limits.
+
+def main(args: argparse.Namespace) -> None:
+    """Configures and submits job array chunks to the Slurm cluster.
+
+    Strategy (inspired by the Airflow Slurm provider):
+      1. Split the input listing into chunks of ``CHUNK_SIZE`` (< MaxArraySize).
+      2. Submit the first chunk as a Slurm job array via submitit.
+      3. **Block** until every task in that chunk reaches a terminal state,
+         showing a live tqdm progress bar.
+      4. Only then submit the next chunk.
+
+    This sequential, one-array-at-a-time approach ensures the cluster's
+    ``MaxJobCount`` is never saturated, at the cost of lower parallelism
+    compared to submitting all chunks simultaneously.
+
+    Each submission is retried up to ``SUBMIT_MAX_RETRIES`` times with
+    linear backoff to handle transient sbatch failures.
 
     Args:
-        args (argparse.Namespace): The parsed command-line arguments containing
-            paths and Slurm configuration variables.
+        args (argparse.Namespace): Parsed CLI arguments (paths + Slurm config).
     """
-    # Create log directory
-    # DTZ002: Use datetime.now with a timezone instead of today()
+    # Timestamped sub-directory keeps each run's logs isolated.
     output_dir_with_date = Path(args.output_dir) / datetime.datetime.now(
         datetime.timezone.utc
     ).strftime("%Y%m%dT%H%M%S")
-
-    # Use instance method for directory creation
     output_dir_with_date.mkdir(parents=True, exist_ok=True)
 
     logger.info("Submitit logs will be stored in: %s", output_dir_with_date)
     logger.info("Bash script to execute: %s", args.bash_slurm_exec)
-
+    logger.info(
+        "Submission strategy: sequential batches (1 array at a time, blocking poll)"
+    )
+    mem_gb = parse_memory_to_gb(args.mem)
+    logger.info("Parsed memory argument: %s -> %.2f GB", args.mem, mem_gb)
     executor = submitit.AutoExecutor(folder=output_dir_with_date, cluster="slurm")
-
-    # Slurm Configuration
     executor.update_parameters(
         timeout_min=args.timeout_min,
-        mem_gb=args.mem_gb,
+        mem_gb=mem_gb,
         cpus_per_task=args.cpus_per_task,
         slurm_partition=args.slurm_partition,
         slurm_array_parallelism=args.slurm_array_parallelism,
@@ -201,8 +560,6 @@ def main(args: argparse.Namespace) -> None:
         slurm_additional_parameters={"export": "ALL,PYTHONUNBUFFERED=1"},
     )
 
-    # Read inputs
-    # Use Path object method to correctly open the file (fixes mypy overload error)
     with Path(args.listing_input).open("r", encoding="utf-8") as f:
         array_inputs = [line.strip() for line in f if line.strip()]
 
@@ -210,62 +567,89 @@ def main(args: argparse.Namespace) -> None:
         logger.error("Input listing file is empty. Aborting submission.")
         return
 
-    # Define the chunk size (e.g., 1000)
-    chunk_size = 1000
-    all_jobs = []
-
+    total_chunks = (len(array_inputs) + CHUNK_SIZE - 1) // CHUNK_SIZE
     logger.info("Total tasks to submit: %d", len(array_inputs))
-
-    # Calculate total number of chunks for logging
-    total_chunks = (len(array_inputs) + chunk_size - 1) // chunk_size
     logger.info(
-        "Submitting tasks in chunks of %d (Total chunks: %d)...",
-        chunk_size,
-        total_chunks,
+        "Submitting in chunks of %d (%d chunks total)...", CHUNK_SIZE, total_chunks
     )
 
-    process_func = functools.partial(process_line, args.bash_slurm_exec)
+    process_func = functools.partial(process_line, args.bash_slurm_exec)  # type: ignore[type-arg]
 
-    # Loop through the inputs in chunks
-    for chunk_idx, i in enumerate(range(0, len(array_inputs), chunk_size), start=1):
-        # Attendre de la place avant chaque soumission
-        wait_for_queue_space(MAX_JOBS_IN_QUEUE, QUEUE_POLL_INTERVAL)
+    global_completed = 0
+    global_failed = 0
 
-        chunk = array_inputs[i : i + chunk_size]
-        logger.info(
-            "Submitting chunk %d/%d (size: %d, starting at index %d)...",
-            chunk_idx,
-            total_chunks,
-            len(chunk),
-            i,
-        )
+    # Outer progress bar tracks batch-level progress across all chunks.
+    with tqdm(
+        total=total_chunks,
+        desc="Overall batches",
+        unit="batch",
+        dynamic_ncols=True,
+        leave=True,
+        file=sys.stdout,
+    ) as outer_pbar:
+        for chunk_idx, i in enumerate(range(0, len(array_inputs), CHUNK_SIZE), start=1):
+            chunk = array_inputs[i : i + CHUNK_SIZE]
+            logger.debug(
+                "=== Batch %d/%d — tasks %d to %d (%d tasks) ===",
+                chunk_idx,
+                total_chunks,
+                i,
+                i + len(chunk) - 1,
+                len(chunk),
+            )
 
-        jobs = executor.map_array(process_func, chunk)
-        logger.info(
-            "Chunk %d submitted. Job Array ID: %s",
-            chunk_idx,
-            jobs[0].job_id,
-        )
-        all_jobs.extend(jobs)
+            # Submit with retry on transient sbatch failures.
+            jobs = submit_chunk_with_retry(
+                executor, process_func, chunk, chunk_idx, total_chunks
+            )
+
+            # Block until this batch is fully done before submitting the next one.
+            # This is the key throttling mechanism: at most one array in flight.
+            completed, failed = wait_for_batch_completion(jobs, chunk_idx, total_chunks)
+            global_completed += completed
+            global_failed += failed
+
+            outer_pbar.update(1)
+            outer_pbar.set_postfix(
+                {
+                    "completed": global_completed,
+                    "failed": global_failed,
+                }
+            )
+
+            if failed and args.fail_fast:
+                logger.error(
+                    "Batch %d/%d had %d failure(s) and --fail-fast is set. "
+                    "Aborting remaining %d batches.",
+                    chunk_idx,
+                    total_chunks,
+                    failed,
+                    total_chunks - chunk_idx,
+                )
+                break
+
     logger.info(
-        "Successfully submitted all %d tasks across %d Job Arrays.",
-        len(all_jobs),
+        "All done — total_submitted=%d  completed=%d  failed=%d  across %d batch(es).",
+        global_completed + global_failed,
+        global_completed,
+        global_failed,
         total_chunks,
     )
+    logger.info(
+        "Task logs are in: %s/<ARRAY_ID>_<TASK_ID>_0_log.out",
+        output_dir_with_date,
+    )
 
-    if all_jobs:
-        logger.info("First Job Array Main Job ID: %s", all_jobs[0].job_id)
-        logger.info(
-            "To monitor specific task logs, use: tail -f %s/<JOB_ID>_<TASK_ID>_0.out",
-            output_dir_with_date,
-        )
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 
 def entrypoint() -> None:
-    """Script entrypoint.
+    """Script entry point.
 
-    Calls the argument parser and passes the resulting arguments to the
-    main execution function.
+    Parses CLI arguments and delegates to :func:`main`.
     """
     args = parser_args()
     main(args)

--- a/src/turboblast/blaster.py
+++ b/src/turboblast/blaster.py
@@ -310,7 +310,7 @@ def wait_for_batch_completion(
                     # Ces exceptions sont attendues dans le contexte submitit/Slurm
                     logger.debug("Job state query failed: %s: %s", type(e).__name__, e)
                     state = "UNKNOWN"
-                except Exception as e:
+                except (KeyboardInterrupt, SystemExit, OSError) as e:
                     # Attraper les autres exceptions mais avec log de warning
                     # et propagation des exceptions système critiques
                     if isinstance(e, (KeyboardInterrupt, SystemExit)):

--- a/src/turboblast/blaster.py
+++ b/src/turboblast/blaster.py
@@ -217,7 +217,7 @@ def submit_chunk_with_retry(
             )
             return jobs
 
-        except Exception as exc:
+        except (OSError, RuntimeError, ValueError, TypeError) as exc:
             # Catch all exceptions during submission to enable retry logic.
             # Transient failures (network, Slurm congestion, etc.) can raise
             # various exception types. We preserve the last exception to

--- a/tests/test_blaster.py
+++ b/tests/test_blaster.py
@@ -6,7 +6,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from turboblast.blaster import main, parser_args, process_line
+from turboblast.blaster import (
+    main,
+    parse_memory_to_gb,
+    parser_args,
+    process_line,
+    submit_chunk_with_retry,
+)
 
 # ─── process_line ────────────────────────────────────────────────────────────
 
@@ -55,6 +61,41 @@ class TestProcessLine:
             assert "file with spaces.nc" in cmd
 
 
+# ─── parse_memory_to_gb ──────────────────────────────────────────────────────
+
+
+class TestParseMemoryToGb:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("2G", 2.0),
+            ("2g", 2.0),
+            ("2GB", 2.0),
+            ("2gb", 2.0),
+            ("1024M", 1.0),
+            ("512M", 0.5),
+            ("512MB", 0.5),
+            ("100M", 100 / 1024),
+            ("2", 2.0),  # bare int → gigabytes (backward compat)
+        ],
+    )
+    def test_valid_values(self, value, expected):
+        assert parse_memory_to_gb(value) == pytest.approx(expected)
+
+    @pytest.mark.parametrize("value", ["abc", "G", "MB", "2X", ""])
+    def test_invalid_values_raise(self, value):
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_memory_to_gb(value)
+
+    def test_zero_raises(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_memory_to_gb("0G")
+
+    def test_negative_raises(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_memory_to_gb("-1G")
+
+
 # ─── parser_args ─────────────────────────────────────────────────────────────
 
 
@@ -77,13 +118,25 @@ class TestParserArgs:
             args = parser_args()
             assert args.num_tasks == 20
             assert args.timeout_min == 20
-            assert args.mem_gb == 2
+            assert args.mem == "2G"  # new: string, not int
             assert args.cpus_per_task == 1
             assert args.slurm_partition == "cpu"
             assert args.slurm_array_parallelism == 20
             assert args.output_dir == "submitit_logs_array"
+            assert args.fail_fast is False
+            assert args.batch_stall_timeout_min == 0
 
-    def test_custom_values(self):
+    def test_custom_mem_gb(self):
+        with patch("sys.argv", ["blaster", *self.BASE_ARGS, "--mem", "8G"]):
+            args = parser_args()
+            assert args.mem == "8G"
+
+    def test_custom_mem_mb(self):
+        with patch("sys.argv", ["blaster", *self.BASE_ARGS, "--mem", "512M"]):
+            args = parser_args()
+            assert args.mem == "512M"
+
+    def test_custom_partition_and_timeout(self):
         with patch(
             "sys.argv",
             [
@@ -91,20 +144,75 @@ class TestParserArgs:
                 *self.BASE_ARGS,
                 "--timeout-min",
                 "60",
-                "--mem-gb",
-                "8",
                 "--slurm-partition",
                 "gpu",
             ],
         ):
             args = parser_args()
             assert args.timeout_min == 60
-            assert args.mem_gb == 8
             assert args.slurm_partition == "gpu"
+
+    def test_fail_fast_flag(self):
+        with patch("sys.argv", ["blaster", *self.BASE_ARGS, "--fail-fast"]):
+            args = parser_args()
+            assert args.fail_fast is True
+
+    def test_batch_stall_timeout(self):
+        with patch(
+            "sys.argv",
+            ["blaster", *self.BASE_ARGS, "--batch-stall-timeout-min", "15"],
+        ):
+            args = parser_args()
+            assert args.batch_stall_timeout_min == 15
 
     def test_missing_required_args_exits(self):
         with patch("sys.argv", ["blaster"]), pytest.raises(SystemExit):
             parser_args()
+
+
+# ─── submit_chunk_with_retry ─────────────────────────────────────────────────
+
+
+class TestSubmitChunkWithRetry:
+    def _make_executor(self, job_id: str = "42") -> MagicMock:
+        mock_job = MagicMock()
+        mock_job.job_id = job_id
+        executor = MagicMock()
+        executor.map_array.return_value = [mock_job]
+        return executor
+
+    def test_success_on_first_attempt(self):
+        executor = self._make_executor()
+        func = MagicMock()
+        jobs = submit_chunk_with_retry(executor, func, ["a", "b"], 1, 3)
+        assert len(jobs) == 1
+        executor.map_array.assert_called_once()
+
+    def test_retries_on_failure_then_succeeds(self):
+        executor = MagicMock()
+        mock_job = MagicMock()
+        mock_job.job_id = "99"
+        # Fail on first attempt, succeed on second attempt (max retries = 2)
+        executor.map_array.side_effect = [
+            RuntimeError("sbatch failed"),
+            [mock_job],  # succeed on second attempt
+        ]
+        with patch("turboblast.blaster.time.sleep"):
+            jobs = submit_chunk_with_retry(executor, MagicMock(), ["a"], 1, 1)
+        assert jobs == [mock_job]
+        assert executor.map_array.call_count == 2  # 1 failure + 1 success = 2 calls
+
+    def test_raises_after_max_retries(self):
+        executor = MagicMock()
+        # Fail all attempts (max retries = 2, so 2 failures)
+        executor.map_array.side_effect = RuntimeError("sbatch always fails")
+        with (
+            patch("turboblast.blaster.time.sleep"),
+            pytest.raises(RuntimeError, match="submission failed after 2 attempts"),
+        ):
+            submit_chunk_with_retry(executor, MagicMock(), ["a"], 1, 1)
+        # SUBMIT_MAX_RETRIES = 2, so 2 attempts total
+        assert executor.map_array.call_count == 2
 
 
 # ─── main ─────────────────────────────────────────────────────────────────────
@@ -124,10 +232,12 @@ class TestMain:
             bash_slurm_exec="/scripts/run.sh",
             output_dir=str(tmp_path / "logs"),
             timeout_min=20,
-            mem_gb=2,
+            mem="2G",  # new: string
             cpus_per_task=1,
             slurm_partition="cpu",
             slurm_array_parallelism=20,
+            fail_fast=False,  # new
+            batch_stall_timeout_min=0,  # new
         )
 
     def test_submits_jobs(self, tmp_path):
@@ -137,11 +247,22 @@ class TestMain:
         mock_job.job_id = "12345"
         mock_executor.map_array.return_value = [mock_job, mock_job]
 
-        with patch(
-            "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
+        with (
+            patch(
+                "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
+            ),
+            # Mock wait_for_batch_completion to avoid blocking on real Slurm.
+            patch(
+                "turboblast.blaster.wait_for_batch_completion",
+                return_value=(2, 0),
+            ),
         ):
             main(args)
-            mock_executor.map_array.assert_called_once()
+            # Vérifier que map_array a été appelé avec les bons arguments
+            call_args = mock_executor.map_array.call_args
+            assert call_args is not None
+            # Le deuxième argument devrait être la liste des inputs
+            assert len(call_args[0][1]) == 2
 
     def test_empty_input_file_aborts(self, tmp_path):
         args = self._make_args(tmp_path, lines=[])
@@ -161,11 +282,18 @@ class TestMain:
         mock_job.job_id = "99"
         mock_executor.map_array.return_value = [mock_job]
 
-        with patch(
-            "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
+        with (
+            patch(
+                "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
+            ),
+            patch(
+                "turboblast.blaster.wait_for_batch_completion",
+                return_value=(1000, 0),
+            ),
         ):
             main(args)
-            assert mock_executor.map_array.call_count == 3  # 1000 + 1000 + 500
+            # Vérifier que map_array a été appelé 3 fois (1000 + 1000 + 500)
+            assert mock_executor.map_array.call_count == 3
 
     def test_blank_lines_ignored(self, tmp_path):
         args = self._make_args(
@@ -176,9 +304,40 @@ class TestMain:
         mock_job.job_id = "1"
         mock_executor.map_array.return_value = [mock_job, mock_job]
 
-        with patch(
-            "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
+        with (
+            patch(
+                "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
+            ),
+            patch(
+                "turboblast.blaster.wait_for_batch_completion",
+                return_value=(2, 0),
+            ),
         ):
             main(args)
+            # Vérifier que seulement 2 inputs ont été soumis (les lignes vides ignorées)
             submitted = mock_executor.map_array.call_args[0][1]
             assert len(submitted) == 2
+
+    def test_fail_fast_stops_after_first_failure(self, tmp_path):
+        """With fail_fast=True and a failing batch, only 1 chunk should be submitted."""
+        args = self._make_args(tmp_path, lines=[f"--input {i}.nc" for i in range(2500)])
+        args.fail_fast = True
+        mock_executor = MagicMock()
+        mock_job = MagicMock()
+        mock_job.job_id = "99"
+        mock_executor.map_array.return_value = [mock_job]
+
+        with (
+            patch(
+                "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
+            ),
+            # First batch has failures (900 completed, 100 failed)
+            patch(
+                "turboblast.blaster.wait_for_batch_completion",
+                return_value=(900, 100),
+            ),
+        ):
+            main(args)
+            # fail_fast → stopped after first batch, not 3
+            # Note: Le premier batch contient 1000 tâches (CHUNK_SIZE=1000)
+            assert mock_executor.map_array.call_count == 1

--- a/tests/test_blaster.py
+++ b/tests/test_blaster.py
@@ -2,7 +2,7 @@ import argparse
 import subprocess
 from pathlib import Path
 from typing import ClassVar
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -12,6 +12,7 @@ from turboblast.blaster import (
     parser_args,
     process_line,
     submit_chunk_with_retry,
+    wait_for_batch_completion,
 )
 
 # ─── process_line ────────────────────────────────────────────────────────────
@@ -53,7 +54,6 @@ class TestProcessLine:
             assert mock_run.call_args[1]["shell"] is False
 
     def test_options_with_quoted_strings(self):
-        """shlex.split should correctly handle quoted arguments."""
         with patch("turboblast.blaster.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             process_line("/script.sh", '--input "file with spaces.nc"')
@@ -76,7 +76,7 @@ class TestParseMemoryToGb:
             ("512M", 0.5),
             ("512MB", 0.5),
             ("100M", 100 / 1024),
-            ("2", 2.0),  # bare int → gigabytes (backward compat)
+            ("2", 2.0),
         ],
     )
     def test_valid_values(self, value, expected):
@@ -118,7 +118,7 @@ class TestParserArgs:
             args = parser_args()
             assert args.num_tasks == 20
             assert args.timeout_min == 20
-            assert args.mem == "2G"  # new: string, not int
+            assert args.mem == "2G"
             assert args.cpus_per_task == 1
             assert args.slurm_partition == "cpu"
             assert args.slurm_array_parallelism == 20
@@ -192,27 +192,110 @@ class TestSubmitChunkWithRetry:
         executor = MagicMock()
         mock_job = MagicMock()
         mock_job.job_id = "99"
-        # Fail on first attempt, succeed on second attempt (max retries = 2)
         executor.map_array.side_effect = [
             RuntimeError("sbatch failed"),
-            [mock_job],  # succeed on second attempt
+            [mock_job],
         ]
         with patch("turboblast.blaster.time.sleep"):
             jobs = submit_chunk_with_retry(executor, MagicMock(), ["a"], 1, 1)
         assert jobs == [mock_job]
-        assert executor.map_array.call_count == 2  # 1 failure + 1 success = 2 calls
+        assert executor.map_array.call_count == 2
 
     def test_raises_after_max_retries(self):
         executor = MagicMock()
-        # Fail all attempts (max retries = 2, so 2 failures)
         executor.map_array.side_effect = RuntimeError("sbatch always fails")
         with (
             patch("turboblast.blaster.time.sleep"),
             pytest.raises(RuntimeError, match="submission failed after 2 attempts"),
         ):
             submit_chunk_with_retry(executor, MagicMock(), ["a"], 1, 1)
-        # SUBMIT_MAX_RETRIES = 2, so 2 attempts total
         assert executor.map_array.call_count == 2
+
+
+# ─── wait_for_batch_completion ───────────────────────────────────────────────
+
+
+class TestWaitForBatchCompletion:
+    def test_all_jobs_complete_successfully(self):
+        jobs = []
+        for _i in range(3):
+            job = MagicMock()
+            # Simuler la propriété state avec des valeurs changeantes
+            state_mock = PropertyMock(side_effect=["RUNNING", "RUNNING", "COMPLETED"])
+            type(job).state = state_mock
+            jobs.append(job)
+
+        with (
+            patch("turboblast.blaster.time.sleep") as _,
+            patch("turboblast.blaster.tqdm"),
+            patch("turboblast.blaster.BATCH_POLL_INTERVAL", 0.001),
+        ):
+            completed, failed = wait_for_batch_completion(jobs, 1, 1, 0)
+            assert completed == 3
+            assert failed == 0
+
+    def test_some_jobs_fail(self):
+        jobs = []
+        job1 = MagicMock()
+        type(job1).state = PropertyMock(side_effect=["RUNNING", "COMPLETED"])
+        job2 = MagicMock()
+        type(job2).state = PropertyMock(side_effect=["RUNNING", "FAILED"])
+        jobs = [job1, job2]
+
+        with (
+            patch("turboblast.blaster.time.sleep"),
+            patch("turboblast.blaster.tqdm"),
+            patch("turboblast.blaster.BATCH_POLL_INTERVAL", 0.001),
+        ):
+            completed, failed = wait_for_batch_completion(jobs, 1, 1, 0)
+            assert completed == 1
+            assert failed == 1
+
+    def test_stall_timeout_triggers_cancellation(self):
+        jobs = []
+        for i in range(2):
+            job = MagicMock()
+            type(job).state = PropertyMock(return_value="RUNNING")
+            job.job_id = f"1234{i}"
+            jobs.append(job)
+
+        # Simuler l'écoulement du temps : après quelques appels, dépasser le timeout
+        time_values = [0.0, 0.1, 0.2, 0.3, 0.4, 120.0] * 10  # assez de valeurs
+        mock_monotonic = MagicMock(side_effect=time_values)
+
+        with (
+            patch("turboblast.blaster.time.sleep") as _,
+            patch("turboblast.blaster.BATCH_POLL_INTERVAL", 0.001),
+            patch("turboblast.blaster.tqdm"),
+            patch("turboblast.blaster.subprocess.run") as mock_run,
+            patch("time.monotonic", mock_monotonic),
+        ):
+            completed, failed = wait_for_batch_completion(
+                jobs, 1, 1, stall_timeout_min=1
+            )
+            assert mock_run.call_count == 2
+            mock_run.assert_any_call(["scancel", "12340"], check=False)
+            mock_run.assert_any_call(["scancel", "12341"], check=False)
+            assert completed == 0
+            assert failed == 2
+
+    def test_exception_during_state_fetch(self):
+        """When job.state raises an exception, treat as UNKNOWN and retry."""
+        job = MagicMock()
+        # Une exception au premier appel, puis COMPLETED
+        state_mock = PropertyMock(side_effect=[RuntimeError("error"), "COMPLETED"])
+        type(job).state = state_mock
+        jobs = [job]
+
+        # Réduire l'intervalle de poll pour éviter les délais
+        with (
+            patch("turboblast.blaster.time.sleep"),
+            patch("turboblast.blaster.BATCH_POLL_INTERVAL", 0.001),
+            patch("turboblast.blaster.tqdm"),
+        ):
+            completed, failed = wait_for_batch_completion(jobs, 1, 1, 0)
+            assert completed == 1
+            assert failed == 0
 
 
 # ─── main ─────────────────────────────────────────────────────────────────────
@@ -232,12 +315,12 @@ class TestMain:
             bash_slurm_exec="/scripts/run.sh",
             output_dir=str(tmp_path / "logs"),
             timeout_min=20,
-            mem="2G",  # new: string
+            mem="2G",
             cpus_per_task=1,
             slurm_partition="cpu",
             slurm_array_parallelism=20,
-            fail_fast=False,  # new
-            batch_stall_timeout_min=0,  # new
+            fail_fast=False,
+            batch_stall_timeout_min=0,
         )
 
     def test_submits_jobs(self, tmp_path):
@@ -251,23 +334,16 @@ class TestMain:
             patch(
                 "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
             ),
-            # Mock wait_for_batch_completion to avoid blocking on real Slurm.
-            patch(
-                "turboblast.blaster.wait_for_batch_completion",
-                return_value=(2, 0),
-            ),
+            patch("turboblast.blaster.wait_for_batch_completion", return_value=(2, 0)),
         ):
             main(args)
-            # Vérifier que map_array a été appelé avec les bons arguments
             call_args = mock_executor.map_array.call_args
             assert call_args is not None
-            # Le deuxième argument devrait être la liste des inputs
             assert len(call_args[0][1]) == 2
 
     def test_empty_input_file_aborts(self, tmp_path):
         args = self._make_args(tmp_path, lines=[])
         mock_executor = MagicMock()
-
         with patch(
             "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
         ):
@@ -275,7 +351,6 @@ class TestMain:
             mock_executor.map_array.assert_not_called()
 
     def test_chunks_large_input(self, tmp_path):
-        """Input > 1000 lines should produce multiple map_array calls."""
         args = self._make_args(tmp_path, lines=[f"--input {i}.nc" for i in range(2500)])
         mock_executor = MagicMock()
         mock_job = MagicMock()
@@ -287,12 +362,10 @@ class TestMain:
                 "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
             ),
             patch(
-                "turboblast.blaster.wait_for_batch_completion",
-                return_value=(1000, 0),
+                "turboblast.blaster.wait_for_batch_completion", return_value=(1000, 0)
             ),
         ):
             main(args)
-            # Vérifier que map_array a été appelé 3 fois (1000 + 1000 + 500)
             assert mock_executor.map_array.call_count == 3
 
     def test_blank_lines_ignored(self, tmp_path):
@@ -308,18 +381,13 @@ class TestMain:
             patch(
                 "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
             ),
-            patch(
-                "turboblast.blaster.wait_for_batch_completion",
-                return_value=(2, 0),
-            ),
+            patch("turboblast.blaster.wait_for_batch_completion", return_value=(2, 0)),
         ):
             main(args)
-            # Vérifier que seulement 2 inputs ont été soumis (les lignes vides ignorées)
             submitted = mock_executor.map_array.call_args[0][1]
             assert len(submitted) == 2
 
     def test_fail_fast_stops_after_first_failure(self, tmp_path):
-        """With fail_fast=True and a failing batch, only 1 chunk should be submitted."""
         args = self._make_args(tmp_path, lines=[f"--input {i}.nc" for i in range(2500)])
         args.fail_fast = True
         mock_executor = MagicMock()
@@ -331,13 +399,53 @@ class TestMain:
             patch(
                 "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
             ),
-            # First batch has failures (900 completed, 100 failed)
             patch(
-                "turboblast.blaster.wait_for_batch_completion",
-                return_value=(900, 100),
+                "turboblast.blaster.wait_for_batch_completion", return_value=(900, 100)
             ),
         ):
             main(args)
-            # fail_fast → stopped after first batch, not 3
-            # Note: Le premier batch contient 1000 tâches (CHUNK_SIZE=1000)
             assert mock_executor.map_array.call_count == 1
+
+    def test_fail_fast_false_continues_after_failures(self, tmp_path):
+        """With fail_fast=False, continue to next batches even if failures occur."""
+        args = self._make_args(tmp_path, lines=[f"--input {i}.nc" for i in range(2500)])
+        args.fail_fast = False
+        mock_executor = MagicMock()
+        mock_job = MagicMock()
+        mock_job.job_id = "99"
+        mock_executor.map_array.return_value = [mock_job]
+
+        # Trois chunks → trois résultats
+        side_effects = [
+            (900, 100),
+            (1000, 0),
+            (1000, 0),
+        ]  # premier échoue, les autres réussissent
+        with (
+            patch(
+                "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
+            ),
+            patch(
+                "turboblast.blaster.wait_for_batch_completion",
+                side_effect=side_effects,
+            ),
+        ):
+            main(args)
+            # fail_fast=False → tous les chunks sont soumis
+            assert mock_executor.map_array.call_count == 3
+
+    def test_output_dir_creation_with_timestamp(self, tmp_path):
+        args = self._make_args(tmp_path)
+        mock_executor = MagicMock()
+        mock_executor.map_array.return_value = [MagicMock(), MagicMock()]
+        with (
+            patch(
+                "turboblast.blaster.submitit.AutoExecutor", return_value=mock_executor
+            ),
+            patch("turboblast.blaster.wait_for_batch_completion", return_value=(2, 0)),
+        ):
+            main(args)
+            output_dir = Path(args.output_dir)
+            subdirs = list(output_dir.glob("*"))
+            assert len(subdirs) == 1
+            assert subdirs[0].name.startswith("20")


### PR DESCRIPTION
MaxJobCount = 25000 — c'est la limite globale du cluster (tous utilisateurs confondus), et 
MaxArraySize = 1001 — un job array ne peut pas dépasser 1001 tâches.

Avec 25000 lignes et chunk_size=1000, tu soumets 25 arrays × ~1000 tâches = ~25000 jobs qui entrent tous en queue d'un coup. 

- [x] code correction for limit 25000 Jobs
- [x] validation on a dummy example
- [x] linter
- [x] add unit tests
- [x] add sphinx doc
- [x] successful unit test